### PR TITLE
copy default options for each asciinema node to not share the reference

### DIFF
--- a/sphinxcontrib/asciinema/asciinema.py
+++ b/sphinxcontrib/asciinema/asciinema.py
@@ -85,7 +85,8 @@ class ASCIINemaDirective(SphinxDirective):
             node.cast_file = self.add_file(arg)
         else:
             node.cast_id = arg
-        node.options = self.env.config['sphinxcontrib_asciinema_defaults']
+        # copy default options, otherwise reference is shared between all nodes
+        node.options = dict(self.env.config['sphinxcontrib_asciinema_defaults'])
         node.options.update(self.options)
         return [node]
 


### PR DESCRIPTION
Fixes #5 
Signed-off-by: Jonas Bulik <jonas@bulik.dev>