### PR TITLE
Custom css

### DIFF
--- a/sphinxcontrib/asciinema/_static/asciinema-custom.css
+++ b/sphinxcontrib/asciinema/_static/asciinema-custom.css
@@ -4,7 +4,7 @@
 }
 
 .asciinema-terminal {
-  font-family: Consolas, Menlo, 'Bitstream Vera Sans Mono', monospace, 'Powerline Symbols' !important;
+  font-family: Consolas, Menlo, 'Bitstream Vera Sans Mono', monospace, 'Powerline Symbols';
 }
 
 .asciinema-player-wrapper {

--- a/sphinxcontrib/asciinema/asciinema.py
+++ b/sphinxcontrib/asciinema/asciinema.py
@@ -28,7 +28,7 @@ class Asciinema(nodes.General, nodes.Element):
 
 def visit_html(self, node):
     if node['type'] == 'local':
-        template = '<asciinema-player {options} src="{src}"></asciinema-player>'
+        template = '<asciinema-player {options} src="data:application/json;base64,{src}" />'
         option_template = '{}="{}" '
         src = node['content']
     else:
@@ -88,7 +88,7 @@ class ASCIINemaDirective(SphinxDirective):
             path += '/'
         fname = arg if arg.startswith('./') else path + arg
         if self.is_file(fname):
-            kw['content'] = self.add_file(fname)
+            kw['content'] = self.to_b64(fname)
             kw['type'] = 'local'
             logger.debug('asciinema: added cast file %s' % fname)
         else:
@@ -103,30 +103,12 @@ class ASCIINemaDirective(SphinxDirective):
         file_path = self.env.relfn2path(rel_file)[1]
         return os.path.isfile(file_path)
 
-    def add_file(self, rel_file):
-        file_path = self.env.relfn2path(rel_file)[1]
-        sha256_hash = sha256(file_path)
-
-        # Copy file to _asset build path.
-        target_dir = os.path.join(self.env.app.outdir, '_casts', sha256_hash)
-        copy_asset(file_path, target_dir)
-
-        # Determine relative path from doc to _asset build path.
-        target_file_uri = posixpath.join('_casts', sha256_hash,
-                                         os.path.basename(rel_file))
-        try:
-            doc_uri = self.env.app.builder.get_target_uri(self.env.docname)
-            return relative_uri(doc_uri, target_file_uri)
-        except NoUri:
-            return None
-
-
-def sha256(fname):
-    hash_sha256 = hashlib.sha256()
-    with open(fname, "rb") as f:
-        for chunk in iter(lambda: f.read(4096), b""):
-            hash_sha256.update(chunk)
-    return hash_sha256.hexdigest()
+    def to_b64(self, filename):
+        import base64
+        with open(filename, 'rb') as file:
+            content = file.read()
+        b64encoded = base64.b64encode(content)
+        return b64encoded.decode()
 
 
 _NODE_VISITORS = {

--- a/sphinxcontrib/asciinema/asciinema.py
+++ b/sphinxcontrib/asciinema/asciinema.py
@@ -1,14 +1,10 @@
-import hashlib
 import os
-import posixpath
 
 from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.util.fileutil import copy_asset
 from sphinx.util.docutils import SphinxDirective
-from sphinx.util.osutil import relative_uri
 from sphinx.util import logging
-from sphinx.errors import NoUri
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The `!important` in the `asciinema-custom.css`  file makes it impossible to override it

I want to be able to override the `asciinema-custom.css` adding this to `conf.py`:
```python
html_css_files = [
    'css/asciinema-custom.css', 'css/copybutton.css'
]
```
then have a custom font in `_static/fonts` and then use my custom font in `_static/css/asciinema_custom.css`

```css
@font-face {
    font-family: 'MesloLGS NF Regular';
    src: url('../fonts/MesloLGS NF Regular.ttf') format('truetype');
}

.asciinema-terminal {
        font-family: 'MesloLGS NF Regular', Consolas, Menlo, 'Bitstream Vera Sans Mono', monospace, 'Powerline Symbols';
}
```