### PR TITLE
[REVIEW] Real path for cast file was not correct

### DIFF
--- a/sphinxcontrib/asciinema/asciinema.py
+++ b/sphinxcontrib/asciinema/asciinema.py
@@ -101,7 +101,8 @@ class ASCIINemaDirective(SphinxDirective):
 
     def to_b64(self, filename):
         import base64
-        with open(filename, 'rb') as file:
+        file_path = self.env.relfn2path(filename)[1]
+        with open(file_path, 'rb') as file:
             content = file.read()
         b64encoded = base64.b64encode(content)
         return b64encoded.decode()


### PR DESCRIPTION
The path used for cast file was not correctly set and plugin could not be used without error