### PR TITLE
Enable parallel build in Sphinx

### DIFF
--- a/sphinxcontrib/asciinema/__init__.py
+++ b/sphinxcontrib/asciinema/__init__.py
@@ -22,4 +22,3 @@ def setup(app):
         'parallel_read_safe': True, 
         'parallel_write_safe': True,
     }
-    

--- a/sphinxcontrib/asciinema/__init__.py
+++ b/sphinxcontrib/asciinema/__init__.py
@@ -16,3 +16,10 @@ def setup(app):
 
     app.add_node(Asciinema, **_NODE_VISITORS)
     app.add_directive('asciinema', ASCIINemaDirective)
+
+    return {
+        'version': __version__, 
+        'parallel_read_safe': True, 
+        'parallel_write_safe': True,
+    }
+    


### PR DESCRIPTION
Hello! Thanks for making this extension. I use it to build my site and it's great. I noticed that Sphinx throws a warning about not specifying whether or not this extension allows for parallel reads and writes. When that happens Sphinx falls back on serial reads, which is a lot slower in my case. 

This PR enables parallel building. I looked at your source code and as far as I can tell it meets the requirements. They are:

>  The parallel-read-safe extension must satisfy the following conditions: 
>   - The core logic of the extension is parallelly executable during the reading phase.
>   - It has event handlers for env-merge-info and env-purge-doc events if it stores data to the build environment object (env) during the reading phase.

I can't find any global state that could be corrupted or inconsistent during the read phase and you only read from the config object, you don't write it. The rule for the write phase is: 

> The parallel-write-safe extension must satisfy the following conditions:
>  - The core logic of the extension is parallelly executable during the writing phase.

From what I can see there is no write hook, writing is taken care of by sphinx. You can find the text I referenced here: 

https://www.sphinx-doc.org/en/master/extdev/index.html 

I hope this helps! 