### PR TITLE
Fix Pip Install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ import io
 import os
 import setuptools
 
+here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = '\n' + f.read()
 
 about = {}
-here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, "sphinxcontrib", "asciinema", '__init__.py')) as f:
     exec(f.read(), about)
 

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,22 @@
+import io
+import os
 import setuptools
-from sphinxcontrib import asciinema as pkg
 
-pkgname = pkg.__name__
+with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = '\n' + f.read()
 
-with open('README.md', 'r') as fh:
-    long_description = fh.read()
+about = {}
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, "sphinxcontrib", "asciinema", '__init__.py')) as f:
+    exec(f.read(), about)
 
 setuptools.setup(
-    name=pkgname,
-    version=pkg.__version__,
+    name="sphinxcontrib.asciinema",
+    version=about['__version__'],
     packages=setuptools.find_packages(),
     install_requires=['sphinx'],
     include_package_data=True,
-    license=pkg.__license__,
+    license=about['__license__'],
     url='https://github.com/divi255/sphinxcontrib.asciinema',
     description='''Embed asciinema casts in your Sphinx docs''',
     long_description_content_type='text/markdown',

--- a/sphinxcontrib/asciinema/__init__.py
+++ b/sphinxcontrib/asciinema/__init__.py
@@ -1,6 +1,6 @@
-__copyright__ = 'Copyright (C) 2019'
+__copyright__ = 'Copyright (C) 2023'
 __license__ = 'MIT'
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 
 def setup(app):


### PR DESCRIPTION
Fixed directly importing package before it was installed in the `setup.py` file. I updated it so it would read in the file's variables and use them like that instead.