### PR TITLE
Add Sphinx Extension PyPi classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
     long_description=long_description,
     namespace_packages=['sphinxcontrib'],
     classifiers='''
+Framework :: Sphinx :: Extension
 Programming Language :: Python
 License :: OSI Approved :: MIT License
 Programming Language :: Python :: 3


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).

You may also want to add the [sphinx-extension](https://github.com/topics/sphinx-extension) repo topic, there are over 200 other extensions using it.