### PR TITLE
Fix `path` bugs

### DIFF
--- a/sphinxcontrib/asciinema/asciinema.py
+++ b/sphinxcontrib/asciinema/asciinema.py
@@ -94,7 +94,7 @@ class ASCIINemaDirective(SphinxDirective):
             kw['content'] = arg
             kw['type'] = 'remote'
             logger.debug('asciinema: added cast id %s' % arg)
-        if 'path ' in kw['options']:
+        if 'path' in kw['options']:
             del kw['options']['path']
         return [Asciinema(**kw)]
 

--- a/sphinxcontrib/asciinema/asciinema.py
+++ b/sphinxcontrib/asciinema/asciinema.py
@@ -82,7 +82,7 @@ class ASCIINemaDirective(SphinxDirective):
         options = dict(self.env.config['sphinxcontrib_asciinema_defaults'])
         options.update(self.options)
         kw = {'options': options}
-        path = self.options.get('path', '')
+        path = options.get('path', '')
         if path and not path.endswith('/'):
             path += '/'
         fname = arg if arg.startswith('./') else path + arg


### PR DESCRIPTION
This pull request fixes two bugs with the `path` option:
1. Setting a `path` in the `sphinxcontrib_asciinema_defaults` does not have an effect, since the `path` option is only taken from the directive's own options.
2. The `path` is passed on to the `Asciinema` class due to a space character in the searched key.
