### PR TITLE
Fix: Only create the AsciinemaPlayer after the page is fully loaded.

### DIFF
--- a/sphinxcontrib/asciinema/asciinema.py
+++ b/sphinxcontrib/asciinema/asciinema.py
@@ -41,10 +41,12 @@ def visit_html(self, node):
     if node['type'] == 'local':
         template = """<div id="asciicast-{id}"></div>
             <script>
-                AsciinemaPlayer.create(
-                    "data:text/plain;base64,{src}",
-                    document.getElementById('asciicast-{id}'),
-                    {{{options} }});
+                document.addEventListener("DOMContentLoaded", function() {{
+                    AsciinemaPlayer.create(
+                        "data:text/plain;base64,{src}",
+                        document.getElementById('asciicast-{id}'),
+                        {{{options} }});
+                }});
             </script>"""
         option_template = '{}: "{}", '
         option_template_raw = '{}: {}, '


### PR DESCRIPTION
If we don't do this the script will start before the asciinema player js file is loaded, resulting in an error and the player never appearing.